### PR TITLE
Fix "To" Field in GMail

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -14562,7 +14562,7 @@ CSS
 .buj {
     background-image: url(//ssl.gstatic.com/ui/v1/icons/mail/rfr/density_compact_v1_1x.png) !important;
 }
-div[class*="bym"][role="navigation"] {
+div[class*="bym"][role="navigation"], .afC, .agJ {
     background-color: var(--darkreader-neutral-background) !important;
 }
 .ain .TO,
@@ -14572,7 +14572,7 @@ div[class*="bym"][role="navigation"] {
 ::-webkit-scrollbar-thumb {
     background-color: #424242 !important;
 }
-::-webkit-scrollbar {
+::-webkit-scrollbar, .agh, .afV {
     background-color: transparent !important
 }
 .aRg,


### PR DESCRIPTION
In the "To" field in GMail, the autofill list was not being inverted. Additionally, once auto populated, the name-card was not being inverted. This PR fixes both bugs.

I couldn't find where the color for the back of the message box was defined, so I just made the name-cards transparent (which produces the same effect).

Let me know if there are any changes I should make to better conform to CSS/darkreader style/conventions :D